### PR TITLE
Add HuggingFace provider, AI sprite-sheet editing/generation and Android packaging

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1075,7 +1075,7 @@ const App: React.FC = () => {
                 <AiUpscalingWindow title={WindowType.AI_UPSCALE} onClose={() => handleCloseWindow(WindowType.AI_UPSCALE)} gridElementRef={gridElementRef} onUpscaleImage={aiService.upscaleImage} />
             )}
             {openWindows[WindowType.AI_SPRITE_SHEET] && (
-                <AiSpriteSheetWindow title={WindowType.AI_SPRITE_SHEET} onClose={() => handleCloseWindow(WindowType.AI_SPRITE_SHEET)} gridElementRef={gridElementRef} onGenerateSpriteSheet={aiService.generateSpriteSheet} />
+                <AiSpriteSheetWindow title={WindowType.AI_SPRITE_SHEET} onClose={() => handleCloseWindow(WindowType.AI_SPRITE_SHEET)} gridElementRef={gridElementRef} onEditSpriteSheet={aiService.editSpriteSheet} onGenerateDirectionalSpriteSheet={aiService.generateDirectionalSpriteSheet} />
             )}
              {openWindows[WindowType.FILTERS] && (
                 <FiltersWindow title={WindowType.FILTERS} onClose={() => handleCloseWindow(WindowType.FILTERS)} filters={filterSettings} onFiltersChange={setFilterSettings} onReset={() => setFilterSettings(initialFilterSettings)} onOpenWindow={handleOpenWindow} />

--- a/README.md
+++ b/README.md
@@ -1,20 +1,66 @@
-<div align="center">
-<img width="1200" height="475" alt="GHBanner" src="https://github.com/user-attachments/assets/0aa67016-6eaf-458a-adb2-6e31a0763ed6" />
-</div>
+# Pixilit Android-Ready Pixel Art + AI Sprite Studio
 
-# Run and deploy your AI Studio app
+Pixilit is now configured as a **full-featured pixel-art and sprite editor** with AI workflows geared for game pipelines (including Godot-style sprite-sheet animation import).
 
-This contains everything you need to run your app locally.
+## Core capabilities
 
-View your app in AI Studio: https://ai.studio/apps/drive/10Elsx6Xj-gfn4BacsIhY8jYCgQoaWiEe
+- Pixel art editor with layers, timeline, tools, filters, palette workflows, and export pipeline.
+- AI-powered sprite-sheet generation from current canvas or uploaded reference image.
+- AI prompt-based sprite/sprite-sheet editing.
+- Directional animation generation presets:
+  - 4-direction character sheets (N/E/S/W)
+  - 8-direction character sheets
+- AI provider support for:
+  - Gemini
+  - OpenRouter
+  - HuggingFace Inference API
+  - Local models via Ollama
 
-## Run Locally
+## AI provider setup
 
-**Prerequisites:**  Node.js
+Open **Settings → AI Provider** and choose your backend.
 
+- **Gemini**: add one or more Gemini API keys.
+- **OpenRouter**: add one or more OpenRouter API keys.
+- **HuggingFace**: add one or more HuggingFace API keys and configure model IDs.
+- **Ollama (local models)**: point to your local server URL (default `http://localhost:11434`).
 
-1. Install dependencies:
-   `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
-   `npm run dev`
+## Run locally
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Start app
+   ```bash
+   npm run dev
+   ```
+
+## Android APK packaging (Capacitor)
+
+The project is configured for Android packaging via Capacitor.
+
+1. Build web assets:
+   ```bash
+   npm run build
+   ```
+2. Sync Capacitor Android project:
+   ```bash
+   npm run android:sync
+   ```
+3. Open Android Studio project:
+   ```bash
+   npm run android:open
+   ```
+4. Build APK from Android Studio, or from CLI:
+   ```bash
+   npm run android:apk:debug
+   ```
+
+Output debug APK path:
+`android/app/build/outputs/apk/debug/app-debug.apk`
+
+## Notes
+
+- HuggingFace model availability differs by account and endpoint permissions.
+- For best sprite-sheet consistency, use prompt constraints such as fixed palette, transparent background, and row-per-direction format.

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,0 +1,10 @@
+const config = {
+  appId: 'com.pixelit.app',
+  appName: 'Pixilit',
+  webDir: 'dist',
+  server: {
+    androidScheme: 'https',
+  },
+};
+
+export default config;

--- a/components/AiSpriteSheetWindow.tsx
+++ b/components/AiSpriteSheetWindow.tsx
@@ -1,5 +1,3 @@
-
-
 import React, { useState, useCallback, RefObject } from 'react';
 import DraggableWindow from './DraggableWindow';
 import PixelatedButton from './PixelatedButton';
@@ -9,92 +7,149 @@ interface AiSpriteSheetWindowProps {
   title: string;
   onClose: () => void;
   gridElementRef: RefObject<HTMLDivElement>;
-  onGenerateSpriteSheet: (base64: string, prompt: string) => Promise<string | null>;
+  onEditSpriteSheet: (base64: string, prompt: string) => Promise<string | null>;
+  onGenerateDirectionalSpriteSheet: (base64: string, prompt: string, directions: 4 | 8, framesPerDirection: number) => Promise<string | null>;
 }
 
-const AiSpriteSheetWindow: React.FC<AiSpriteSheetWindowProps> = ({ title, onClose, gridElementRef, onGenerateSpriteSheet }) => {
-  const [prompt, setPrompt] = useState('8-frame walk cycle to the right');
+const AiSpriteSheetWindow: React.FC<AiSpriteSheetWindowProps> = ({
+  title,
+  onClose,
+  gridElementRef,
+  onEditSpriteSheet,
+  onGenerateDirectionalSpriteSheet,
+}) => {
+  const [prompt, setPrompt] = useState('armored knight walk cycle with sword and shield');
+  const [mode, setMode] = useState<'generate' | 'edit'>('generate');
+  const [directions, setDirections] = useState<4 | 8>(4);
+  const [framesPerDirection, setFramesPerDirection] = useState(8);
+  const [uploadedBase64, setUploadedBase64] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [spriteSheetImage, setSpriteSheetImage] = useState<string | null>(null);
 
+  const getCanvasBase64 = useCallback(async () => {
+    if (!gridElementRef.current) return null;
+    const canvas = await html2canvas(gridElementRef.current, { backgroundColor: null });
+    return canvas.toDataURL('image/png').split(',')[1];
+  }, [gridElementRef]);
+
+  const handleUploadImage = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : '';
+      setUploadedBase64(result.split(',')[1] || null);
+    };
+    reader.readAsDataURL(file);
+  };
+
   const handleGenerate = useCallback(async () => {
-    if (!gridElementRef.current || isLoading || !prompt) return;
-    
+    if (isLoading || !prompt) return;
+
     setIsLoading(true);
     setError(null);
     setSpriteSheetImage(null);
 
     try {
-      const canvas = await html2canvas(gridElementRef.current, { backgroundColor: null });
-      const base64ImageData = canvas.toDataURL('image/png').split(',')[1];
-      
-      const result = await onGenerateSpriteSheet(base64ImageData, prompt);
-      
+      const base64ImageData = uploadedBase64 || await getCanvasBase64();
+      if (!base64ImageData) throw new Error('No source sprite found. Draw on canvas or upload an image.');
+
+      const result = mode === 'edit'
+        ? await onEditSpriteSheet(base64ImageData, prompt)
+        : await onGenerateDirectionalSpriteSheet(base64ImageData, prompt, directions, framesPerDirection);
+
       if (result) {
         setSpriteSheetImage(`data:image/png;base64,${result}`);
       } else {
-        setError('Failed to generate sprite sheet.');
+        setError('Failed to generate sprite sheet. Try another model or prompt.');
       }
     } catch (e: any) {
       setError(e.message || 'An unexpected error occurred.');
     } finally {
       setIsLoading(false);
     }
-  }, [isLoading, gridElementRef, prompt, onGenerateSpriteSheet]);
-  
+  }, [isLoading, prompt, uploadedBase64, getCanvasBase64, mode, onEditSpriteSheet, onGenerateDirectionalSpriteSheet, directions, framesPerDirection]);
+
   const handleDownload = () => {
-    if (spriteSheetImage) {
-        const link = document.createElement('a');
-        link.href = spriteSheetImage;
-        link.download = `sprite-sheet.png`;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-    }
+    if (!spriteSheetImage) return;
+    const link = document.createElement('a');
+    link.href = spriteSheetImage;
+    link.download = `sprite-sheet-${mode}.png`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
   };
 
   return (
-    <DraggableWindow title={title} onClose={onClose} width="w-[500px]" height="h-auto">
+    <DraggableWindow title={title} onClose={onClose} width="w-[540px]" height="h-auto">
       <div className="bg-transparent h-full flex flex-col p-2 gap-2 text-xs text-cyan-300">
-        <p>Generate an animation sprite sheet from your current art. Describe the animation below.</p>
-        
-        <div className="flex flex-col gap-2">
-            <input
-                type="text"
-                value={prompt}
-                onChange={e => setPrompt(e.target.value)}
-                placeholder="e.g., 8-frame walk cycle to the right"
-                className="w-full p-2 bg-black/50 border-2 border-cyan-400 text-cyan-300 placeholder-cyan-700"
-                disabled={isLoading}
-            />
-            <PixelatedButton onClick={handleGenerate} disabled={isLoading || !prompt}>
-                {isLoading ? 'Generating...' : 'Generate Sprite Sheet'}
-            </PixelatedButton>
+        <p>Create or edit sprite sheets from canvas art or uploaded references. Optimized for game engines like Godot.</p>
+
+        <div className="grid grid-cols-2 gap-2">
+          <label className="flex flex-col gap-1">
+            Mode
+            <select className="bg-black/80 border border-cyan-400 p-1" value={mode} onChange={(e) => setMode(e.target.value as 'generate' | 'edit')}>
+              <option value="generate">Generate Animation Sheet</option>
+              <option value="edit">Prompt Edit Existing Sheet</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            Upload source sprite/image (optional)
+            <input type="file" accept="image/*" onChange={handleUploadImage} className="bg-black/80 border border-cyan-400 p-1" />
+          </label>
         </div>
+
+        {mode === 'generate' && (
+          <div className="grid grid-cols-2 gap-2">
+            <label className="flex flex-col gap-1">
+              Direction set
+              <select value={directions} onChange={e => setDirections(Number(e.target.value) as 4 | 8)} className="bg-black/80 border border-cyan-400 p-1">
+                <option value={4}>4-directional (N/E/S/W)</option>
+                <option value={8}>8-directional</option>
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              Frames per direction
+              <input type="number" min={2} max={16} value={framesPerDirection} onChange={e => setFramesPerDirection(Number(e.target.value) || 8)} className="bg-black/80 border border-cyan-400 p-1" />
+            </label>
+          </div>
+        )}
+
+        <textarea
+          value={prompt}
+          onChange={e => setPrompt(e.target.value)}
+          placeholder="Describe sprite, animation, palette, and style constraints"
+          className="w-full p-2 bg-black/50 border-2 border-cyan-400 text-cyan-300 placeholder-cyan-700 min-h-[80px]"
+          disabled={isLoading}
+        />
+
+        <PixelatedButton onClick={handleGenerate} disabled={isLoading || !prompt}>
+          {isLoading ? 'Generating...' : mode === 'edit' ? 'Edit Sprite Sheet from Prompt' : 'Generate 4/8-Direction Sprite Sheet'}
+        </PixelatedButton>
 
         {error && <p className="text-red-400 text-center my-2">{error}</p>}
 
-        <div className="flex-grow mt-2 p-2 border-2 border-cyan-400/50 min-h-[200px] flex items-center justify-center bg-black/30">
-            {isLoading && <p>Loading...</p>}
-            {spriteSheetImage && (
-                <img 
-                    src={spriteSheetImage} 
-                    alt="Generated Sprite Sheet" 
-                    className="max-w-full max-h-full object-contain" 
-                    style={{
-                        imageRendering: 'pixelated',
-                        backgroundImage: `linear-gradient(45deg, #444 25%, transparent 25%), linear-gradient(-45deg, #444 25%, transparent 25%)`,
-                        backgroundSize: `10px 10px`,
-                    }}
-                />
-            )}
+        <div className="flex-grow mt-2 p-2 border-2 border-cyan-400/50 min-h-[220px] flex items-center justify-center bg-black/30">
+          {isLoading && <p>Loading...</p>}
+          {spriteSheetImage && (
+            <img
+              src={spriteSheetImage}
+              alt="Generated Sprite Sheet"
+              className="max-w-full max-h-full object-contain"
+              style={{
+                imageRendering: 'pixelated',
+                backgroundImage: `linear-gradient(45deg, #444 25%, transparent 25%), linear-gradient(-45deg, #444 25%, transparent 25%)`,
+                backgroundSize: `10px 10px`,
+              }}
+            />
+          )}
         </div>
-        
-         {spriteSheetImage && (
-            <PixelatedButton onClick={handleDownload} className="w-full mt-2">
-                Download Sprite Sheet
-            </PixelatedButton>
+
+        {spriteSheetImage && (
+          <PixelatedButton onClick={handleDownload} className="w-full mt-2">
+            Download Sprite Sheet PNG
+          </PixelatedButton>
         )}
       </div>
     </DraggableWindow>

--- a/components/SettingsWindow.tsx
+++ b/components/SettingsWindow.tsx
@@ -36,6 +36,7 @@ const SettingsWindow: React.FC<SettingsWindowProps> = ({ title, onClose, initial
                     case AIProvider.COHERE:
                     case AIProvider.OPENROUTER:
                     case AIProvider.OPENAI:
+                    case AIProvider.HUGGINGFACE:
                         providerError = "Failed to fetch models. Is the API key correct?"; break;
                 }
             }
@@ -75,7 +76,7 @@ const SettingsWindow: React.FC<SettingsWindowProps> = ({ title, onClose, initial
     // Fetch models on initial load or provider change
     useEffect(() => {
         handleFetchModels();
-    }, [settings.provider, settings.ollamaUrl, settings.geminiApiKeys, settings.mistralApiKeys, settings.cohereApiKeys, settings.openrouterApiKeys, settings.openaiApiKeys]);
+    }, [settings.provider, settings.ollamaUrl, settings.geminiApiKeys, settings.mistralApiKeys, settings.cohereApiKeys, settings.openrouterApiKeys, settings.openaiApiKeys, settings.huggingfaceApiKeys]);
 
     const handleSave = () => {
         onSave(settings);
@@ -194,6 +195,21 @@ const SettingsWindow: React.FC<SettingsWindowProps> = ({ title, onClose, initial
                     )}
                     {settings.provider === AIProvider.OPENAI && (
                         <ApiKeyManager provider={AIProvider.OPENAI} keys={settings.openaiApiKeys} onKeysChange={newKeys => setSettings(s => ({...s, openaiApiKeys: newKeys}))} />
+                    )}
+                    {settings.provider === AIProvider.HUGGINGFACE && (
+                        <>
+                            <ApiKeyManager provider={AIProvider.HUGGINGFACE} keys={settings.huggingfaceApiKeys} onKeysChange={newKeys => setSettings(s => ({...s, huggingfaceApiKeys: newKeys}))} />
+                            <div className="flex flex-col gap-1">
+                                <label>HuggingFace Inference Base URL:</label>
+                                <input
+                                    type="text"
+                                    value={settings.huggingfaceBaseUrl}
+                                    onChange={(e) => setSettings(prev => ({ ...prev, huggingfaceBaseUrl: e.target.value }))}
+                                    placeholder="https://api-inference.huggingface.co/models"
+                                    className="w-full p-1 bg-black/80 border border-cyan-400"
+                                />
+                            </div>
+                        </>
                     )}
                 </div>
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "android:sync": "npx cap sync android",
+    "android:open": "npx cap open android",
+    "android:apk:debug": "npm run build && npx cap sync android && cd android && ./gradlew assembleDebug"
   },
   "dependencies": {
     "react": "^19.2.0",
@@ -15,12 +18,15 @@
     "html2canvas": "^1.4.1",
     "uuid": "^13.0.0",
     "jszip": "latest",
-    "gif.js": "latest"
+    "gif.js": "latest",
+    "@capacitor/core": "^6.2.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
     "@vitejs/plugin-react": "^5.0.0",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "@capacitor/cli": "^6.2.0",
+    "@capacitor/android": "^6.2.0"
   }
 }

--- a/services/aiService.ts
+++ b/services/aiService.ts
@@ -6,6 +6,7 @@ import * as mistralService from './mistralService';
 import * as cohereService from './cohereService';
 import * as openrouterService from './openrouterService';
 import * as openaiService from './openaiService';
+import * as huggingfaceService from './huggingfaceService';
 
 let settings: AISettings;
 
@@ -38,6 +39,10 @@ const initializeKeyStates = (s: AISettings) => {
         currentIndex: 0,
         errorCounts: Array(s.openaiApiKeys.length).fill(0),
     };
+    keyStates[AIProvider.HUGGINGFACE] = {
+        currentIndex: 0,
+        errorCounts: Array(s.huggingfaceApiKeys.length).fill(0),
+    };
 };
 
 const getApiKeyForProvider = (provider: AIProvider): string | undefined => {
@@ -50,6 +55,7 @@ const getApiKeyForProvider = (provider: AIProvider): string | undefined => {
     else if (provider === AIProvider.COHERE) keys = settings.cohereApiKeys;
     else if (provider === AIProvider.OPENROUTER) keys = settings.openrouterApiKeys;
     else if (provider === AIProvider.OPENAI) keys = settings.openaiApiKeys;
+    else if (provider === AIProvider.HUGGINGFACE) keys = settings.huggingfaceApiKeys;
 
     return keys[state.currentIndex];
 };
@@ -73,6 +79,7 @@ const reportErrorForProvider = (provider: AIProvider) => {
         else if (provider === AIProvider.COHERE) keys = settings.cohereApiKeys;
         else if (provider === AIProvider.OPENROUTER) keys = settings.openrouterApiKeys;
         else if (provider === AIProvider.OPENAI) keys = settings.openaiApiKeys;
+        else if (provider === AIProvider.HUGGINGFACE) keys = settings.huggingfaceApiKeys;
         
         if (keys.length > 1) {
             console.warn(`API key for ${provider} failed ${ERROR_THRESHOLD} times. Switching to the next key.`);
@@ -104,7 +111,7 @@ export const init = (newSettings: AISettings) => {
 // --- Service Functions ---
 
 export const listModels = async (): Promise<AiModel[]> => {
-    const apiKeyProviders = [AIProvider.GEMINI, AIProvider.MISTRAL, AIProvider.COHERE, AIProvider.OPENAI];
+    const apiKeyProviders = [AIProvider.GEMINI, AIProvider.MISTRAL, AIProvider.COHERE, AIProvider.OPENAI, AIProvider.HUGGINGFACE];
     const isApiKeyProvider = apiKeyProviders.includes(settings.provider);
 
     try {
@@ -124,6 +131,9 @@ export const listModels = async (): Promise<AiModel[]> => {
             case AIProvider.OPENAI: {
                 const apiKey = getApiKeyForProvider(AIProvider.OPENAI);
                 return await openaiService.listModels(apiKey || '');
+            }
+            case AIProvider.HUGGINGFACE: {
+                return await huggingfaceService.listModels(settings.models[AIProvider.HUGGINGFACE].image);
             }
             case AIProvider.GEMINI:
             default:
@@ -151,6 +161,8 @@ export const generatePixelArt = (
             return withErrorHandling(AIProvider.OPENROUTER, () => openrouterService.generatePixelArt(prompt, artMode, resolution, settings.models[AIProvider.OPENROUTER], getApiKeyForProvider(AIProvider.OPENROUTER)!, image, styleGuide));
         case AIProvider.OPENAI:
             return withErrorHandling(AIProvider.OPENAI, () => openaiService.generatePixelArt(prompt, artMode, resolution, settings.models[AIProvider.OPENAI], getApiKeyForProvider(AIProvider.OPENAI)!, image, styleGuide));
+        case AIProvider.HUGGINGFACE:
+            return withErrorHandling(AIProvider.HUGGINGFACE, () => huggingfaceService.generatePixelArt(prompt, artMode, resolution, settings.models[AIProvider.HUGGINGFACE].image, getApiKeyForProvider(AIProvider.HUGGINGFACE)!));
         case AIProvider.GEMINI:
         default:
              return withErrorHandling(AIProvider.GEMINI, () => geminiService.generatePixelArt(getApiKeyForProvider(AIProvider.GEMINI)!, prompt, artMode, resolution, settings.models[AIProvider.GEMINI], image, styleGuide));
@@ -169,6 +181,11 @@ export const getPromptSuggestions = (currentPrompt: string): Promise<string[] | 
             return withErrorHandling(AIProvider.OPENROUTER, () => openrouterService.getPromptSuggestions(currentPrompt, settings.models[AIProvider.OPENROUTER].text, getApiKeyForProvider(AIProvider.OPENROUTER)!));
         case AIProvider.OPENAI:
             return withErrorHandling(AIProvider.OPENAI, () => openaiService.getPromptSuggestions(currentPrompt, settings.models[AIProvider.OPENAI].text, getApiKeyForProvider(AIProvider.OPENAI)!));
+        case AIProvider.HUGGINGFACE:
+            return withErrorHandling(AIProvider.HUGGINGFACE, async () => {
+                const suggestionText = await huggingfaceService.sendChatMessage(getApiKeyForProvider(AIProvider.HUGGINGFACE)!, settings.models[AIProvider.HUGGINGFACE].text, `Suggest 5 concise prompt ideas for: ${currentPrompt}. Return one per line.`);
+                return suggestionText ? suggestionText.split('\n').map(s => s.trim()).filter(Boolean).slice(0, 5) : null;
+            });
         case AIProvider.GEMINI:
         default:
             return withErrorHandling(AIProvider.GEMINI, () => geminiService.getPromptSuggestions(getApiKeyForProvider(AIProvider.GEMINI)!, currentPrompt, settings.models[AIProvider.GEMINI].text));
@@ -223,6 +240,8 @@ export const upscaleImage = (base64ImageData: string, scaleFactor: number): Prom
             return withErrorHandling(AIProvider.OPENROUTER, () => openrouterService.upscaleImage(base64ImageData, scaleFactor, settings.models[AIProvider.OPENROUTER].vision, getApiKeyForProvider(AIProvider.OPENROUTER)!));
         case AIProvider.OPENAI:
             return withErrorHandling(AIProvider.OPENAI, () => openaiService.upscaleImage(base64ImageData, scaleFactor, settings.models[AIProvider.OPENAI].vision, getApiKeyForProvider(AIProvider.OPENAI)!));
+        case AIProvider.HUGGINGFACE:
+            return withErrorHandling(AIProvider.HUGGINGFACE, () => huggingfaceService.editSpriteSheet(base64ImageData, `Upscale this sprite by ${scaleFactor}x while preserving pixel-perfect edges.`, settings.models[AIProvider.HUGGINGFACE].image, getApiKeyForProvider(AIProvider.HUGGINGFACE)!));
         case AIProvider.GEMINI:
         default:
             return withErrorHandling(AIProvider.GEMINI, () => geminiService.upscaleImage(getApiKeyForProvider(AIProvider.GEMINI)!, base64ImageData, scaleFactor, settings.models[AIProvider.GEMINI].vision));
@@ -241,9 +260,36 @@ export const generateSpriteSheet = (base64ImageData: string, prompt: string): Pr
             return withErrorHandling(AIProvider.OPENROUTER, () => openrouterService.generateSpriteSheet(base64ImageData, prompt, settings.models[AIProvider.OPENROUTER].vision, getApiKeyForProvider(AIProvider.OPENROUTER)!));
         case AIProvider.OPENAI:
             return withErrorHandling(AIProvider.OPENAI, () => openaiService.generateSpriteSheet(base64ImageData, prompt, settings.models[AIProvider.OPENAI].vision, getApiKeyForProvider(AIProvider.OPENAI)!));
+        case AIProvider.HUGGINGFACE:
+            return withErrorHandling(AIProvider.HUGGINGFACE, () => huggingfaceService.generateSpriteSheet(base64ImageData, prompt, settings.models[AIProvider.HUGGINGFACE].image, getApiKeyForProvider(AIProvider.HUGGINGFACE)!));
         case AIProvider.GEMINI:
         default:
             return withErrorHandling(AIProvider.GEMINI, () => geminiService.generateSpriteSheet(getApiKeyForProvider(AIProvider.GEMINI)!, base64ImageData, prompt, settings.models[AIProvider.GEMINI].vision));
+    }
+};
+
+export const editSpriteSheet = (base64ImageData: string, prompt: string): Promise<string | null> => {
+    const editPrompt = `Edit this sprite or sprite sheet based on instruction: ${prompt}`;
+    switch (settings.provider) {
+        case AIProvider.HUGGINGFACE:
+            return withErrorHandling(AIProvider.HUGGINGFACE, () => huggingfaceService.editSpriteSheet(base64ImageData, editPrompt, settings.models[AIProvider.HUGGINGFACE].image, getApiKeyForProvider(AIProvider.HUGGINGFACE)!));
+        default:
+            return generateSpriteSheet(base64ImageData, editPrompt);
+    }
+};
+
+export const generateDirectionalSpriteSheet = (
+    base64ImageData: string,
+    prompt: string,
+    directions: 4 | 8,
+    framesPerDirection: number
+): Promise<string | null> => {
+    const directionalPrompt = `Generate a ${directions}-direction sprite sheet with ${framesPerDirection} frames per direction. ${prompt}`;
+    switch (settings.provider) {
+        case AIProvider.HUGGINGFACE:
+            return withErrorHandling(AIProvider.HUGGINGFACE, () => huggingfaceService.generateDirectionalSpriteSheet(base64ImageData, prompt, directions, framesPerDirection, settings.models[AIProvider.HUGGINGFACE].image, getApiKeyForProvider(AIProvider.HUGGINGFACE)!));
+        default:
+            return generateSpriteSheet(base64ImageData, directionalPrompt);
     }
 };
 

--- a/services/huggingfaceService.ts
+++ b/services/huggingfaceService.ts
@@ -1,0 +1,107 @@
+import { AiModel, AIProvider } from '../types';
+
+const HF_ROUTER_URL = 'https://router.huggingface.co/v1/chat/completions';
+const HF_INFERENCE_URL = 'https://api-inference.huggingface.co/models';
+
+const parseDataUrl = (dataUrl: string): string => dataUrl.startsWith('data:') ? dataUrl.split(',')[1] : dataUrl;
+
+const runChatCompletion = async (apiKey: string, model: string, prompt: string): Promise<string | null> => {
+    const response = await fetch(HF_ROUTER_URL, {
+        method: 'POST',
+        headers: {
+            'Authorization': `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            model,
+            messages: [
+                { role: 'system', content: 'You are an expert pixel-art and game-sprite assistant.' },
+                { role: 'user', content: prompt },
+            ],
+        }),
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`HuggingFace chat request failed (${response.status}): ${errorText}`);
+    }
+
+    const data = await response.json();
+    return data?.choices?.[0]?.message?.content || null;
+};
+
+const runImageInference = async (apiKey: string, model: string, prompt: string): Promise<string | null> => {
+    const response = await fetch(`${HF_INFERENCE_URL}/${model}`, {
+        method: 'POST',
+        headers: {
+            'Authorization': `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            inputs: prompt,
+            options: { wait_for_model: true },
+        }),
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`HuggingFace image request failed (${response.status}): ${errorText}`);
+    }
+
+    const blob = await response.blob();
+    const arrayBuffer = await blob.arrayBuffer();
+    return btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
+};
+
+export const listModels = async (configuredModel: string): Promise<AiModel[]> => {
+    return [
+        { name: configuredModel || 'black-forest-labs/FLUX.1-dev', provider: AIProvider.HUGGINGFACE },
+        { name: 'stabilityai/stable-diffusion-xl-base-1.0', provider: AIProvider.HUGGINGFACE },
+        { name: 'black-forest-labs/FLUX.1-schnell', provider: AIProvider.HUGGINGFACE },
+    ];
+};
+
+export const generateSpriteSheet = async (
+    base64ImageData: string,
+    prompt: string,
+    imageModel: string,
+    apiKey: string,
+): Promise<string | null> => {
+    const sourceImage = parseDataUrl(base64ImageData);
+    const fullPrompt = `Create a pixel-art sprite sheet PNG. ${prompt}. Keep a transparent background and consistent character proportions. Source image (base64 PNG): ${sourceImage}`;
+    return runImageInference(apiKey, imageModel, fullPrompt);
+};
+
+export const editSpriteSheet = async (
+    base64ImageData: string,
+    prompt: string,
+    imageModel: string,
+    apiKey: string,
+): Promise<string | null> => {
+    const sourceImage = parseDataUrl(base64ImageData);
+    const fullPrompt = `Edit this existing sprite/sprite-sheet while preserving art style and palette. Instruction: ${prompt}. Existing sheet (base64 PNG): ${sourceImage}`;
+    return runImageInference(apiKey, imageModel, fullPrompt);
+};
+
+export const generateDirectionalSpriteSheet = async (
+    base64ImageData: string,
+    prompt: string,
+    directions: 4 | 8,
+    framesPerDirection: number,
+    imageModel: string,
+    apiKey: string,
+): Promise<string | null> => {
+    const sourceImage = parseDataUrl(base64ImageData);
+    const directionalPrompt = `Generate a ${directions}-direction pixel-art sprite sheet with ${framesPerDirection} animation frames per direction. ${prompt}. Include rows per direction suitable for Godot animation import. Source image (base64 PNG): ${sourceImage}`;
+    return runImageInference(apiKey, imageModel, directionalPrompt);
+};
+
+export const generatePixelArt = async (
+    prompt: string,
+    artMode: string,
+    resolution: number,
+    imageModel: string,
+    apiKey: string,
+): Promise<string | null> => runImageInference(apiKey, imageModel, `${artMode} pixel art, ${resolution}x${resolution}, ${prompt}`);
+
+export const sendChatMessage = async (apiKey: string, model: string, message: string): Promise<string | null> => runChatCompletion(apiKey, model, message);

--- a/services/storageService.ts
+++ b/services/storageService.ts
@@ -16,6 +16,8 @@ const defaultAISettings: AISettings = {
     cohereApiKeys: [],
     openrouterApiKeys: [],
     openaiApiKeys: [],
+    huggingfaceApiKeys: [],
+    huggingfaceBaseUrl: 'https://api-inference.huggingface.co/models',
     models: {
         [AIProvider.GEMINI]: {
             text: 'gemini-2.5-flash',
@@ -46,6 +48,11 @@ const defaultAISettings: AISettings = {
             text: 'gpt-4o-mini',
             image: 'gpt-4o-mini',
             vision: 'gpt-4o-mini',
+        },
+        [AIProvider.HUGGINGFACE]: {
+            text: 'Qwen/Qwen2.5-Coder-32B-Instruct',
+            image: 'black-forest-labs/FLUX.1-dev',
+            vision: 'llava-hf/llava-1.5-7b-hf',
         }
     },
 };
@@ -175,6 +182,10 @@ export const loadAISettings = (): AISettings => {
             if (savedSettings.openaiApiKey) {
                 savedSettings.openaiApiKeys = Array.isArray(savedSettings.openaiApiKey) ? savedSettings.openaiApiKey : [savedSettings.openaiApiKey];
                 delete savedSettings.openaiApiKey;
+            }
+            if (savedSettings.huggingfaceApiKey) {
+                savedSettings.huggingfaceApiKeys = Array.isArray(savedSettings.huggingfaceApiKey) ? savedSettings.huggingfaceApiKey : [savedSettings.huggingfaceApiKey];
+                delete savedSettings.huggingfaceApiKey;
             }
 
 

--- a/types.ts
+++ b/types.ts
@@ -79,6 +79,7 @@ export enum AIProvider {
     COHERE = 'Cohere',
     OPENROUTER = 'OpenRouter',
     OPENAI = 'OpenAI',
+    HUGGINGFACE = 'HuggingFace',
 }
 
 // --- Interfaces & Types ---
@@ -182,6 +183,8 @@ export interface AISettings {
     cohereApiKeys: string[];
     openrouterApiKeys: string[];
     openaiApiKeys: string[];
+    huggingfaceApiKeys: string[];
+    huggingfaceBaseUrl: string;
     models: {
         [key in AIProvider]: {
             text: string;


### PR DESCRIPTION
### Motivation
- Expand AI backend support to include HuggingFace and enable richer sprite workflows (generate, edit, directional sheets) usable from prompt or image for game pipelines like Godot. 
- Provide an Android packaging scaffold so the web app can be packaged as an APK for device installation. 

### Description
- Added HuggingFace as an AI provider in `types.ts` and extended `AISettings` to persist `huggingfaceApiKeys` and `huggingfaceBaseUrl`. 
- Implemented `services/huggingfaceService.ts` with chat and image inference helpers and sprite-focused functions (`generateSpriteSheet`, `editSpriteSheet`, `generateDirectionalSpriteSheet`, etc.).
- Integrated HuggingFace into `services/aiService.ts` (model listing, key rotation, prompt suggestions, pixel-art/image generation paths) and added `editSpriteSheet` and `generateDirectionalSpriteSheet` helpers. 
- Reworked the AI sprite UI: `components/AiSpriteSheetWindow.tsx` now supports canvas capture or uploaded images, prompt-based editing mode, 4/8 directional generation, frames-per-direction control, and PNG download. 
- Extended `components/SettingsWindow.tsx` and `services/storageService.ts` to manage HuggingFace API keys, base URL, and persist/migrate settings with defaults. 
- Wired the window in `App.tsx` to call the new sprite functions, added Capacitor scaffold (`capacitor.config.ts`) and npm scripts in `package.json` to support `cap sync`, `cap open`, and a debug APK build, and updated `README.md` with usage and Android packaging instructions. 

### Testing
- Ran `npm run build` (Vite) and production build completed successfully. ✅
- Ran `npx tsc --noEmit` to verify types and fixes; TypeScript compile (no emit) passed after adjustments. ✅
- Attempted `npm install` to fetch newly added Capacitor packages but it failed in this environment due to registry/access policy (`403 Forbidden` for `@capacitor/android`), so Android package installation was not executed here. ⚠️
- Attempted a Playwright-based UI screenshot to validate the running app UI, but the headless Chromium process crashed (SIGSEGV) in this environment, so no screenshot artifact was produced. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a404d4ad74832aa74a02e9c53d5955)