### PR TITLE
Add Sprite Lab: in-app sprite player, voxelizer, sheet compiler, cookie-cutter and Godot export

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -31,6 +31,7 @@ import AchievementsWindow from './components/AchievementsWindow';
 import AchievementToast from './components/AchievementToast';
 import TutorialGuide from './components/TutorialGuide';
 import SettingsWindow from './components/SettingsWindow';
+import SpriteLabWindow from './components/SpriteLabWindow';
 
 // Types and Constants
 import { Tool, WindowType, Frame, Layer, BlendMode, GridType, VersionHistory, Commit, ProjectState, Asset, MacroAction, Macro, Script, Tutorial, UnlockedAchievement, Achievement, AchievementID, AISettings } from './types';
@@ -1161,6 +1162,9 @@ const App: React.FC = () => {
             )}
             {openWindows[WindowType.ACHIEVEMENTS] && (
                 <AchievementsWindow title={WindowType.ACHIEVEMENTS} onClose={() => handleCloseWindow(WindowType.ACHIEVEMENTS)} unlockedAchievements={unlockedAchievements} />
+            )}
+            {openWindows[WindowType.SPRITE_LAB] && (
+                <SpriteLabWindow title={WindowType.SPRITE_LAB} onClose={() => handleCloseWindow(WindowType.SPRITE_LAB)} />
             )}
             {openWindows[WindowType.SETTINGS] && (
                 <SettingsWindow

--- a/components/SpriteLabWindow.tsx
+++ b/components/SpriteLabWindow.tsx
@@ -1,0 +1,278 @@
+import React, { useMemo, useState } from 'react';
+import DraggableWindow from './DraggableWindow';
+import PixelatedButton from './PixelatedButton';
+import {
+  compileSpriteSheets,
+  createVoxelHeightMap,
+  cropFrame,
+  sliceSpriteSheetToFrames,
+  SpriteFrameRect,
+  SpriteSource,
+} from '../utils/spriteLabUtils';
+
+type Tab = 'player' | 'voxel' | 'compiler' | 'cookie' | 'godot' | 'ai';
+
+interface SpriteLabWindowProps {
+  title: string;
+  onClose: () => void;
+}
+
+const readAsDataUrl = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === 'string' ? reader.result : '');
+    reader.onerror = () => reject(new Error('Failed to read file.'));
+    reader.readAsDataURL(file);
+  });
+
+const openSourceApis = [
+  { name: 'Hugging Face Inference API', url: 'https://huggingface.co/inference-api', note: 'Text/image models (many open-weight).' },
+  { name: 'Replicate', url: 'https://replicate.com/explore', note: 'Hosted OSS model APIs for image and video tasks.' },
+  { name: 'fal.ai', url: 'https://fal.ai/models', note: 'Fast diffusion + image editing models with API access.' },
+  { name: 'OpenRouter', url: 'https://openrouter.ai/models', note: 'Unified model gateway with open model options.' },
+  { name: 'Stability AI API', url: 'https://platform.stability.ai/docs/api-reference', note: 'Stable diffusion and edit workflows.' },
+];
+
+const SpriteLabWindow: React.FC<SpriteLabWindowProps> = ({ title, onClose }) => {
+  const [tab, setTab] = useState<Tab>('player');
+  const [sourceSheet, setSourceSheet] = useState<string | null>(null);
+  const [frameWidth, setFrameWidth] = useState(32);
+  const [frameHeight, setFrameHeight] = useState(32);
+  const [fps, setFps] = useState(8);
+  const [isPlaying, setIsPlaying] = useState(true);
+  const [sheetFrameCount, setSheetFrameCount] = useState(1);
+
+  const [voxelDepth, setVoxelDepth] = useState(6);
+  const [voxelPreview, setVoxelPreview] = useState<string | null>(null);
+
+  const [compileSources, setCompileSources] = useState<SpriteSource[]>([]);
+  const [compileColumns, setCompileColumns] = useState(3);
+  const [compileGap, setCompileGap] = useState(2);
+  const [compiledSheet, setCompiledSheet] = useState<string | null>(null);
+
+  const [cookieRect, setCookieRect] = useState<SpriteFrameRect>({ x: 0, y: 0, width: 16, height: 16 });
+  const [cookieFrames, setCookieFrames] = useState<string[]>([]);
+
+  const [isBusy, setIsBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleUploadPrimary = async (file?: File) => {
+    if (!file) return;
+    const dataUrl = await readAsDataUrl(file);
+    setSourceSheet(dataUrl);
+    const image = new Image();
+    image.onload = () => {
+      const cols = Math.max(1, Math.floor(image.width / Math.max(1, frameWidth)));
+      const rows = Math.max(1, Math.floor(image.height / Math.max(1, frameHeight)));
+      setSheetFrameCount(cols * rows);
+    };
+    image.src = dataUrl;
+    setError(null);
+  };
+
+
+  const playerStyle = useMemo(
+    () => ({
+      backgroundImage: sourceSheet ? `url(${sourceSheet})` : 'none',
+      width: `${frameWidth}px`,
+      height: `${frameHeight}px`,
+      backgroundRepeat: 'no-repeat',
+      imageRendering: 'pixelated' as const,
+      animation: isPlaying ? `sprite-play ${Math.max(0.1, 1 / fps)}s steps(1) infinite` : undefined,
+    }),
+    [sourceSheet, frameWidth, frameHeight, fps, isPlaying],
+  );
+
+  const ensureSource = () => {
+    if (!sourceSheet) throw new Error('Upload a source sprite sheet first.');
+  };
+
+  const buildVoxelPreview = async () => {
+    try {
+      ensureSource();
+      setIsBusy(true);
+      setVoxelPreview(await createVoxelHeightMap(sourceSheet!, voxelDepth));
+      setTab('voxel');
+    } catch (e: any) {
+      setError(e.message || 'Voxel conversion failed.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const handleAddCompileSources = async (files: FileList | null) => {
+    if (!files?.length) return;
+    const loaded = await Promise.all(
+      Array.from(files).map(async (file) => ({
+        id: `${file.name}-${file.lastModified}`,
+        name: file.name,
+        dataUrl: await readAsDataUrl(file),
+      })),
+    );
+    setCompileSources((prev) => [...prev, ...loaded]);
+  };
+
+  const handleCompile = async () => {
+    try {
+      setIsBusy(true);
+      setCompiledSheet(await compileSpriteSheets(compileSources, compileColumns, compileGap, 'transparent'));
+      setTab('compiler');
+    } catch (e: any) {
+      setError(e.message || 'Sprite sheet compilation failed.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const handleCookieCut = async () => {
+    try {
+      ensureSource();
+      setIsBusy(true);
+      const frames = await sliceSpriteSheetToFrames(sourceSheet!, frameWidth, frameHeight);
+      const cropped = await Promise.all(frames.map((frame) => cropFrame(frame, cookieRect)));
+      setCookieFrames(cropped);
+      setTab('cookie');
+    } catch (e: any) {
+      setError(e.message || 'Cookie cutter process failed.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const downloadDataUrl = (dataUrl: string, fileName: string) => {
+    const a = document.createElement('a');
+    a.href = dataUrl;
+    a.download = fileName;
+    a.click();
+  };
+
+  const exportGodotTemplate = async () => {
+    if (!sourceSheet) {
+      setError('Upload a sprite sheet first.');
+      return;
+    }
+
+    const json = {
+      app: 'Pixilit',
+      engine: 'Godot 4.6',
+      spriteSheet: {
+        frameWidth,
+        frameHeight,
+        fps,
+        sourceHint: 'Place exported image in res://art/sprites/',
+      },
+      animation: {
+        name: 'default',
+        loop: true,
+      },
+      generatedAt: new Date().toISOString(),
+    };
+
+    const blob = new Blob([JSON.stringify(json, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    downloadDataUrl(url, 'godot46-pixilit-import.json');
+    URL.revokeObjectURL(url);
+  };
+
+  const aiPrompt = `Touch-up + shading pipeline:\n1) Preserve silhouette and timing\n2) Add directional shading from top-left\n3) Cleanup single-pixel noise\n4) Keep palette under 32 colors\n5) Return sprite sheet unchanged in frame layout`;
+
+  return (
+    <DraggableWindow title={title} onClose={onClose} width="w-[760px]" height="h-auto">
+      <style>{`@keyframes sprite-play { 0% { background-position: 0 0; } 100% { background-position: calc(-1 * var(--sheetWidth, 0px)) 0; }}`}</style>
+      <div className="p-3 text-xs text-cyan-200 flex flex-col gap-3">
+        <div className="grid grid-cols-4 gap-2">
+          <label className="col-span-2 flex flex-col gap-1">
+            Source sprite sheet
+            <input type="file" accept="image/*" onChange={(e) => handleUploadPrimary(e.target.files?.[0])} className="bg-black/60 border border-cyan-400 p-1" />
+          </label>
+          <label className="flex flex-col gap-1">Frame W<input type="number" min={1} value={frameWidth} onChange={(e) => setFrameWidth(Number(e.target.value) || 1)} className="bg-black/60 border border-cyan-400 p-1" /></label>
+          <label className="flex flex-col gap-1">Frame H<input type="number" min={1} value={frameHeight} onChange={(e) => setFrameHeight(Number(e.target.value) || 1)} className="bg-black/60 border border-cyan-400 p-1" /></label>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {(['player', 'voxel', 'compiler', 'cookie', 'godot', 'ai'] as Tab[]).map((entry) => (
+            <PixelatedButton key={entry} onClick={() => setTab(entry)} className={tab === entry ? 'bg-cyan-600/40' : ''}>{entry.toUpperCase()}</PixelatedButton>
+          ))}
+        </div>
+
+        {error && <p className="text-red-400">{error}</p>}
+
+        {tab === 'player' && (
+          <div className="grid grid-cols-2 gap-3 items-start">
+            <div className="space-y-2">
+              <label className="flex items-center gap-2">FPS<input type="range" min={1} max={24} value={fps} onChange={(e) => setFps(Number(e.target.value) || 8)} /></label>
+              <p>Live sprite player enables in-app animation checks before export.</p>
+              <PixelatedButton onClick={() => setIsPlaying((prev) => !prev)}>{isPlaying ? 'Pause' : 'Play'}</PixelatedButton>
+            </div>
+            <div className="min-h-40 border-2 border-cyan-400 p-2 flex items-center justify-center bg-black/40">
+              {sourceSheet ? (
+                <div
+                  style={{ ...playerStyle, ['--sheetWidth' as any]: `${frameWidth * Math.max(sheetFrameCount, 1)}px` }}
+                />
+              ) : <p>Upload a sheet to preview.</p>}
+            </div>
+          </div>
+        )}
+
+        {tab === 'voxel' && (
+          <div className="space-y-2">
+            <label className="flex items-center gap-2">Voxel depth<input type="range" min={1} max={12} value={voxelDepth} onChange={(e) => setVoxelDepth(Number(e.target.value) || 6)} />{voxelDepth}</label>
+            <PixelatedButton onClick={buildVoxelPreview} disabled={isBusy}>Generate Voxel Preview</PixelatedButton>
+            <div className="min-h-52 border border-cyan-400 p-2 bg-black/40 flex items-center justify-center">
+              {voxelPreview ? <img src={voxelPreview} alt="Voxel preview" className="max-h-64 object-contain" style={{ imageRendering: 'pixelated' }} /> : <p>No voxel preview yet.</p>}
+            </div>
+          </div>
+        )}
+
+        {tab === 'compiler' && (
+          <div className="space-y-2">
+            <div className="grid grid-cols-3 gap-2">
+              <label className="flex flex-col">Columns<input type="number" min={1} value={compileColumns} onChange={(e) => setCompileColumns(Number(e.target.value) || 1)} className="bg-black/60 border border-cyan-400 p-1" /></label>
+              <label className="flex flex-col">Gap<input type="number" min={0} value={compileGap} onChange={(e) => setCompileGap(Number(e.target.value) || 0)} className="bg-black/60 border border-cyan-400 p-1" /></label>
+              <label className="flex flex-col">Sheet inputs<input type="file" multiple accept="image/*" onChange={(e) => handleAddCompileSources(e.target.files)} className="bg-black/60 border border-cyan-400 p-1" /></label>
+            </div>
+            <p>{compileSources.length} source sheets queued.</p>
+            <PixelatedButton onClick={handleCompile} disabled={isBusy || compileSources.length === 0}>Compile Unified Sheet</PixelatedButton>
+            {compiledSheet && <><img src={compiledSheet} alt="Compiled sprite sheet" className="max-h-56" style={{ imageRendering: 'pixelated' }} /><PixelatedButton onClick={() => downloadDataUrl(compiledSheet, 'compiled-spritesheet.png')}>Download</PixelatedButton></>}
+          </div>
+        )}
+
+        {tab === 'cookie' && (
+          <div className="space-y-2">
+            <div className="grid grid-cols-4 gap-2">
+              {(['x', 'y', 'width', 'height'] as (keyof SpriteFrameRect)[]).map((key) => (
+                <label key={key} className="flex flex-col capitalize">{key}<input type="number" min={0} value={cookieRect[key]} onChange={(e) => setCookieRect((prev) => ({ ...prev, [key]: Number(e.target.value) || 0 }))} className="bg-black/60 border border-cyan-400 p-1" /></label>
+              ))}
+            </div>
+            <PixelatedButton onClick={handleCookieCut} disabled={isBusy}>Cookie Cutter All Frames</PixelatedButton>
+            <div className="grid grid-cols-6 gap-2 max-h-64 overflow-auto border border-cyan-400 p-2">
+              {cookieFrames.map((frame, idx) => <img key={`${frame}-${idx}`} src={frame} alt={`cookie frame ${idx + 1}`} style={{ imageRendering: 'pixelated' }} className="border border-cyan-500/40" />)}
+            </div>
+          </div>
+        )}
+
+        {tab === 'godot' && (
+          <div className="space-y-2">
+            <p>Direct Godot 4.6 bridge export includes import metadata + animation defaults for AnimatedSprite2D pipelines.</p>
+            <PixelatedButton onClick={exportGodotTemplate}>Export Godot 4.6 Import JSON</PixelatedButton>
+          </div>
+        )}
+
+        {tab === 'ai' && (
+          <div className="space-y-2">
+            <p>Advanced AI editing profile (shading + touch-up):</p>
+            <textarea readOnly value={aiPrompt} className="w-full min-h-24 bg-black/50 border border-cyan-400 p-2" />
+            <p className="font-bold">Additional open/free API options:</p>
+            <ul className="list-disc pl-5 space-y-1">
+              {openSourceApis.map((api) => (
+                <li key={api.name}><a className="underline text-fuchsia-300" href={api.url} target="_blank" rel="noreferrer">{api.name}</a> — {api.note}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </DraggableWindow>
+  );
+};
+
+export default SpriteLabWindow;

--- a/components/StartMenu.tsx
+++ b/components/StartMenu.tsx
@@ -46,6 +46,7 @@ const StartMenu: React.FC<StartMenuProps> = ({ isOpen, onOpenWindow }) => {
             <MenuItem onClick={() => onOpenWindow(WindowType.AI_STYLE_TUNER)}>AI Style Tuner</MenuItem>
             <MenuItem onClick={() => onOpenWindow(WindowType.AI_AUTO_SHADING)}>AI Auto-Shading</MenuItem>
             <MenuItem onClick={() => onOpenWindow(WindowType.AI_LAYER_SEPARATION)}>AI Layer Separation</MenuItem>
+            <MenuItem onClick={() => onOpenWindow(WindowType.SPRITE_LAB)}>Sprite Lab</MenuItem>
             <div className="h-px bg-cyan-400/50 my-1"></div>
             <MenuItem onClick={() => onOpenWindow(WindowType.SETTINGS)}>Settings</MenuItem>
             <MenuItem onClick={() => onOpenWindow(WindowType.EXPORT)}>Export</MenuItem>

--- a/types.ts
+++ b/types.ts
@@ -37,6 +37,7 @@ export enum WindowType {
     AI_STYLE_TUNER = 'AI Style Tuner',
     AI_AUTO_SHADING = 'AI Auto-Shading',
     AI_LAYER_SEPARATION = 'AI Layer Separation',
+    SPRITE_LAB = 'Sprite Lab',
     SETTINGS = 'Settings',
     EXPORT = 'Export',
 }

--- a/utils/spriteLabUtils.ts
+++ b/utils/spriteLabUtils.ts
@@ -1,0 +1,190 @@
+export interface SpriteFrameRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SpriteSource {
+  id: string;
+  name: string;
+  dataUrl: string;
+}
+
+const loadImage = (dataUrl: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error('Failed to load image.'));
+    image.src = dataUrl;
+  });
+
+export const sliceSpriteSheetToFrames = async (
+  dataUrl: string,
+  frameWidth: number,
+  frameHeight: number,
+): Promise<string[]> => {
+  const image = await loadImage(dataUrl);
+  const columns = Math.max(1, Math.floor(image.width / frameWidth));
+  const rows = Math.max(1, Math.floor(image.height / frameHeight));
+  const total = columns * rows;
+  const frames: string[] = [];
+
+  for (let i = 0; i < total; i++) {
+    const col = i % columns;
+    const row = Math.floor(i / columns);
+    const canvas = document.createElement('canvas');
+    canvas.width = frameWidth;
+    canvas.height = frameHeight;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) continue;
+    ctx.imageSmoothingEnabled = false;
+    ctx.clearRect(0, 0, frameWidth, frameHeight);
+    ctx.drawImage(image, col * frameWidth, row * frameHeight, frameWidth, frameHeight, 0, 0, frameWidth, frameHeight);
+    frames.push(canvas.toDataURL('image/png'));
+  }
+
+  return frames;
+};
+
+export const compileSpriteSheets = async (
+  sources: SpriteSource[],
+  columns: number,
+  gap: number,
+  backgroundColor: string,
+): Promise<string> => {
+  if (sources.length === 0) {
+    throw new Error('No sprite sheets selected.');
+  }
+
+  const images = await Promise.all(sources.map((source) => loadImage(source.dataUrl)));
+  const safeColumns = Math.max(1, columns);
+  const rows = Math.ceil(images.length / safeColumns);
+
+  const columnWidths = Array(safeColumns).fill(0);
+  const rowHeights = Array(rows).fill(0);
+
+  images.forEach((img, index) => {
+    const col = index % safeColumns;
+    const row = Math.floor(index / safeColumns);
+    columnWidths[col] = Math.max(columnWidths[col], img.width);
+    rowHeights[row] = Math.max(rowHeights[row], img.height);
+  });
+
+  const width = columnWidths.reduce((sum, current) => sum + current, 0) + gap * (safeColumns - 1);
+  const height = rowHeights.reduce((sum, current) => sum + current, 0) + gap * (rows - 1);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Could not create compiler canvas.');
+
+  if (backgroundColor !== 'transparent') {
+    ctx.fillStyle = backgroundColor;
+    ctx.fillRect(0, 0, width, height);
+  } else {
+    ctx.clearRect(0, 0, width, height);
+  }
+
+  let currentY = 0;
+  for (let row = 0; row < rows; row++) {
+    let currentX = 0;
+    for (let col = 0; col < safeColumns; col++) {
+      const index = row * safeColumns + col;
+      const img = images[index];
+      if (img) ctx.drawImage(img, currentX, currentY);
+      currentX += columnWidths[col] + gap;
+    }
+    currentY += rowHeights[row] + gap;
+  }
+
+  return canvas.toDataURL('image/png');
+};
+
+export const cropFrame = async (dataUrl: string, rect: SpriteFrameRect): Promise<string> => {
+  const image = await loadImage(dataUrl);
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.max(1, rect.width);
+  canvas.height = Math.max(1, rect.height);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Could not create crop canvas.');
+
+  ctx.imageSmoothingEnabled = false;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.drawImage(image, rect.x, rect.y, rect.width, rect.height, 0, 0, rect.width, rect.height);
+
+  return canvas.toDataURL('image/png');
+};
+
+export const createVoxelHeightMap = async (dataUrl: string, depth: number): Promise<string> => {
+  const image = await loadImage(dataUrl);
+  const canvas = document.createElement('canvas');
+  canvas.width = image.width;
+  canvas.height = image.height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Could not create voxel map canvas.');
+
+  ctx.drawImage(image, 0, 0);
+  const pixels = ctx.getImageData(0, 0, image.width, image.height).data;
+
+  const voxelScale = 8;
+  const isoX = voxelScale;
+  const isoY = voxelScale / 2;
+  const out = document.createElement('canvas');
+  out.width = (image.width + image.height) * isoX + 40;
+  out.height = (image.width + image.height) * isoY + depth * voxelScale + 40;
+  const outCtx = out.getContext('2d');
+  if (!outCtx) throw new Error('Could not render voxel preview.');
+
+  outCtx.clearRect(0, 0, out.width, out.height);
+
+  const drawVoxel = (x: number, y: number, h: number, color: string) => {
+    const originX = (x - y) * isoX + out.width / 2;
+    const originY = (x + y) * isoY + 20;
+    const z = h * (voxelScale / 2);
+
+    outCtx.fillStyle = color;
+    outCtx.beginPath();
+    outCtx.moveTo(originX, originY - z);
+    outCtx.lineTo(originX + isoX, originY + isoY - z);
+    outCtx.lineTo(originX, originY + isoY * 2 - z);
+    outCtx.lineTo(originX - isoX, originY + isoY - z);
+    outCtx.closePath();
+    outCtx.fill();
+
+    outCtx.fillStyle = 'rgba(0,0,0,0.2)';
+    outCtx.beginPath();
+    outCtx.moveTo(originX - isoX, originY + isoY - z);
+    outCtx.lineTo(originX, originY + isoY * 2 - z);
+    outCtx.lineTo(originX, originY + isoY * 2 + voxelScale - z);
+    outCtx.lineTo(originX - isoX, originY + isoY + voxelScale - z);
+    outCtx.closePath();
+    outCtx.fill();
+
+    outCtx.fillStyle = 'rgba(255,255,255,0.15)';
+    outCtx.beginPath();
+    outCtx.moveTo(originX + isoX, originY + isoY - z);
+    outCtx.lineTo(originX, originY + isoY * 2 - z);
+    outCtx.lineTo(originX, originY + isoY * 2 + voxelScale - z);
+    outCtx.lineTo(originX + isoX, originY + isoY + voxelScale - z);
+    outCtx.closePath();
+    outCtx.fill();
+  };
+
+  for (let y = 0; y < image.height; y++) {
+    for (let x = 0; x < image.width; x++) {
+      const i = (y * image.width + x) * 4;
+      const alpha = pixels[i + 3];
+      if (alpha < 20) continue;
+      const r = pixels[i];
+      const g = pixels[i + 1];
+      const b = pixels[i + 2];
+      const brightness = (r + g + b) / (3 * 255);
+      const h = Math.max(1, Math.round(brightness * depth));
+      drawVoxel(x, y, h, `rgb(${r},${g},${b})`);
+    }
+  }
+
+  return out.toDataURL('image/png');
+};


### PR DESCRIPTION
### Motivation
- Provide an integrated workspace for advanced sprite workflows: previewing sprite-sheet animations live, turning sprites into voxel previews, compiling multiple sheets into one, batch-cropping frames, exporting metadata for Godot 4.6, and offering AI touch-up/shading tools with open/free API options.

### Description
- Added a new `SpriteLabWindow` UI component that exposes tabs for a live sprite-sheet player, voxel preview generation, multi-sheet compiler, cookie-cutter frame cropping, Godot 4.6 export JSON, and an AI touch-up/shading info panel (`components/SpriteLabWindow.tsx`).
- Implemented reusable image utilities in `utils/spriteLabUtils.ts` providing `sliceSpriteSheetToFrames`, `compileSpriteSheets`, `cropFrame`, and `createVoxelHeightMap` for in-browser processing and preview generation.
- Wired the feature into the app by adding `SPRITE_LAB` to `WindowType` (`types.ts`), inserting a Start Menu entry (`components/StartMenu.tsx`), and importing/rendering the new window in `App.tsx`.
- Added UX conveniences: automatic sheet frame counting, compiled sheet download, cookie-cutter batch cropping, Godot 4.6 import metadata export, and a short list of open/free AI API options (Hugging Face, Replicate, fal.ai, OpenRouter, Stability) for users to connect.

### Testing
- Ran the production build with `npm run build`, which completed successfully.
- Started the dev server with `npm run dev` to validate runtime wiring; server reported ready and served the app (dev server started). 
- Attempted automated browser verification with a Playwright script to open the app and capture the Sprite Lab window; the automation timed out / produced a blank render in the container environment, so UI interaction verification was not completed by the script.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a40ec01430832aa92bc22a03803e82)